### PR TITLE
Add remaining templates from atom/atom

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Create a report to help us improve
 
 <!--
 
-Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/.github/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
 

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -23,24 +23,30 @@ Do you want to ask a question? Are you looking for support? The Atom message boa
 
 ### Description
 
-[Description of the issue]
+<!-- Description of the issue -->
 
 ### Steps to Reproduce
 
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
+1. <!-- First Step -->
+2. <!-- Second Step -->
+3. <!-- and so on… -->
 
-**Expected behavior:** [What you expect to happen]
+**Expected behavior:**
 
-**Actual behavior:** [What actually happens]
+<!-- What you expect to happen -->
 
-**Reproduces how often:** [What percentage of the time does it reproduce?]
+**Actual behavior:**
+
+<!-- What actually happens -->
+
+**Reproduces how often:**
+
+<!-- What percentage of the time does it reproduce? -->
 
 ### Versions
 
-You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
+<!-- You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running. -->
 
 ### Additional Information
 
-Any additional information, configuration or data that might be necessary to reproduce the issue.
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+-->
+
+### Prerequisites
+
+* [ ] Put an X between the brackets on this line if you have done all of the following:
+    * Reproduced the problem in Safe Mode: <https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode>
+    * Followed all applicable steps in the debugging guide: <https://flight-manual.atom.io/hacking-atom/sections/debugging/>
+    * Checked the FAQs on the message board for common solutions: <https://discuss.atom.io/c/faq>
+    * Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom>
+    * Checked that there is not already an Atom package that provides the described functionality: <https://atom.io/packages>
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+### Versions
+
+You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+---
+
+Keep in mind that Atom is highly customizable in a number of ways and we strongly prefer that you consider these options before filing this issue:
+
+* https://flight-manual.atom.io/using-atom/sections/basic-customization/: tweak Atom's configuration, styles, and keybindings.
+* https://flight-manual.atom.io/using-atom/sections/atom-packages/: install a community package.
+* https://flight-manual.atom.io/hacking-atom/: use the Atom API in your init script, to create a package, or to enhance an existing package.
+
+If you're convinced that none of these options are appropriate for the feature you want, please explain why that's the case by completely filling out the issue template below.
+
+Also note that the Atom team has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature however, we'll follow up and ask you to submit an RFC to talk about it in more detail.
+
+-->
+
+## Summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Describe alternatives you've considered
+
+A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -26,16 +26,16 @@ Also note that the Atom team has finite resources so it's unlikely that we'll wo
 
 ## Summary
 
-One paragraph explanation of the feature.
+<!-- One paragraph explanation of the feature. -->
 
 ## Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
 
 ## Describe alternatives you've considered
 
-A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
+<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature. -->
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ about: Suggest an idea for this project
 
 <!--
 
-Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/.github/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.
+
+1. Copy the correct template for your contribution
+  - 🐛 Are you fixing a bug? Copy the template from <https://bit.ly/atom-bugfix>
+  - 📈 Are you improving performance? Copy the template from <https://bit.ly/atom-perf>
+  - 📝 Are you updating documentation? Copy the template from <https://bit.ly/atom-docs>
+  - 💻 Are you changing functionality? Copy the template from <https://bit.ly/atom-behavior>
+2. Replace this text with the contents of the template
+3. Fill in all sections of the template
+4. Click "Create pull request"

--- a/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,9 +1,9 @@
 ### Requirements for Contributing a Bug Fix
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
 * The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
 
 ### Identify the Bug
 

--- a/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,59 @@
+### Requirements for Contributing a Bug Fix
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+
+### Identify the Bug
+
+<!--
+
+Link to the issue describing the bug that you're fixing.
+
+If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
+Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.
+
+-->
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand. This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,7 +1,7 @@
 ### Requirements for Contributing Documentation
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
 
 ### Description of the Change
 

--- a/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,30 @@
+### Requirements for Contributing Documentation
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.
+
+-->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -3,7 +3,7 @@
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 * The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
 * The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
 
 ### Issue or RFC Endorsed by Atom's Maintainers
 
@@ -15,9 +15,9 @@ Link to the issue or RFC that your change relates to. This must be one of the fo
 * An open issue with the `triaged` label
 * An RFC with "accepted" status
 
-To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/atom/blob/master/CONTRIBUTING.md#suggesting-enhancements
+To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements
 
-To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.
 
 -->
 
@@ -56,7 +56,7 @@ Describe the actions you performed (including buttons you clicked, text you type
 <!--
 
 Please describe the changes in a single line that explains this improvement in
-terms that a user can understand.  This text will be used in Atom's release notes.
+terms that a user can understand. This text will be used in Atom's release notes.
 
 If this change is not user-facing or notable enough to be included in release notes
 you may use the strings "Not applicable" or "N/A" here.

--- a/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -1,0 +1,70 @@
+### Requirements for Adding, Changing, or Removing a Feature
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
+* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+
+### Issue or RFC Endorsed by Atom's Maintainers
+
+<!--
+
+Link to the issue or RFC that your change relates to. This must be one of the following:
+
+* An open issue with the `help-wanted` label
+* An open issue with the `triaged` label
+* An RFC with "accepted" status
+
+To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/atom/blob/master/CONTRIBUTING.md#suggesting-enhancements
+
+To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+
+-->
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that your change has the desired effects?
+
+- How did you verify that all new functionality works as expected?
+- How did you verify that all changed functionality works as expected?
+- How did you verify that the change has not introduced any regressions?
+
+Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -1,0 +1,55 @@
+### Requirements for Contributing a Performance Improvement
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Quantitative Performance Benefits
+
+<!--
+
+Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.
+
+-->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -1,8 +1,8 @@
 ### Requirements for Contributing a Performance Improvement
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE>.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.
+* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
 
 ### Description of the Change
 


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom/.github/issues/5

### Description of the Change

Migrates the remaining templates from `atom/atom` that are currently missing from this generic repository for the entire organization, allowing a single central place to maintain them.

### Alternate Designs

We _could_ continue on with the current setup and develop tools to check for repositories that are missing specific templates or have an out of date version, but taking advantage of the feature built into GitHub specifically for this seems the better option.

### Possible Drawbacks

Since **every single** repository in the organization will be using these files if they aren't overriding them locally, some repositories where these templates aren't necessarily applicable will start showing them. Examples include places where we have forked libraries used in Atom to allow customization, or libraries that were created for Atom but are used in other projects.

Examples:
* [node-oniguruma](https://github.com/atom/node-oniguruma)
* [watcher](https://github.com/atom/watcher)
* And more

Another potential drawback of this are projects that may want to use different methods of managing issues, such as the [github](https://github.com/atom/github) package. Some of this case can be mitigated by creating templates within that specific repository to override the ones coming from here.


### Verification Process

This repository follows [the documentation for this feature](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization), unfortunately this can't be verified until it is put in place. Once merged however repositories like [fuzy-finder](https://github.com/atom/fuzzy-finder) should start showing currently missing documents such as the `CODE_OF_CONDUCT`.

### Release Notes

N/A