### PR TITLE
Fix some broken links

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 ⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.
 
 1. Copy the correct template for your contribution
-  - 🐛 Are you fixing a bug? Copy the template from <https://bit.ly/atom-bugfix>
-  - 📈 Are you improving performance? Copy the template from <https://bit.ly/atom-perf>
-  - 📝 Are you updating documentation? Copy the template from <https://bit.ly/atom-docs>
-  - 💻 Are you changing functionality? Copy the template from <https://bit.ly/atom-behavior>
+  - 🐛 Are you fixing a bug? Copy the template from <https://bit.ly/atom-bugfix-pr>
+  - 📈 Are you improving performance? Copy the template from <https://bit.ly/atom-perf-pr>
+  - 📝 Are you updating documentation? Copy the template from <https://bit.ly/atom-docs-pr>
+  - 💻 Are you changing functionality? Copy the template from <https://bit.ly/atom-behavior-pr>
 2. Replace this text with the contents of the template
 3. Fill in all sections of the template
 4. Click "Create pull request"


### PR DESCRIPTION
# Fix templates links

The following links return an error 404: Not Found:

- https://bit.ly/atom-bugfix
- https://bit.ly/atom-perf
- https://bit.ly/atom-docs
- https://bit.ly/atom-behavior

## 🔗 Related

fix #9

Thanks to @rsese who reported me the correct links.