### PR TITLE
Update links

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,8 +4,8 @@ If you're looking for support for Atom there are a lot of options, check out:
 
 * User Documentation &mdash; [The Atom Flight Manual](https://flight-manual.atom.io)
 * Developer Documentation &mdash; [Atom API Documentation](https://atom.io/docs/api/latest)
-* FAQ &mdash; [The Atom FAQ on Discuss](https://discuss.atom.io/c/faq)
-* Message Board &mdash; [Discuss, the official Atom and Electron message board](https://discuss.atom.io)
+* FAQ &mdash; [The Atom FAQ on the Flight Manual](https://flight-manual.atom.io/faq/)
+* Message Board &mdash; [Github Discussions](https://github.com/atom/atom/discussions)
 * Chat &mdash; [Join the Atom Slack team](https://atom-slack.herokuapp.com/)
 
-On Discuss and in the Atom Slack team, there are a bunch of helpful community members that should be willing to point you in the right direction.
+On Github Discussions and in the Atom Slack team, there are a bunch of helpful community members that should be willing to point you in the right direction.


### PR DESCRIPTION
According to https://web.archive.org/web/20201129054807/https://discuss.atom.io/c/faq/12, the flight manual is now the faq
Also, the github discussions replaced the message board

The discuss.atom.io links don't work anymore